### PR TITLE
採用活動ページを非表示にする

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -12,7 +12,6 @@
           <li><a href="business.html">事業紹介</a></li>
           <li><a href="works.html">開発実績</a></li>
           <li><a href="company.html">会社概要</a></li>
-          <li><a href="reqruit.html">採用活動</a></li>
           <li><a href="https://docs.google.com/forms/d/e/1FAIpQLSes34fwJy28yyStVuRQCEqVR5ErI-nJwoWnhgzEofW2-dBPPA/viewform?usp=sf_link" target="_blank">お問い合わせ</a></li>
         </ul>
       </nav>

--- a/reqruit.md
+++ b/reqruit.md
@@ -1,6 +1,7 @@
 ---
 layout: reqruit
 title: "採用活動"
+published: false
 ---
 
 # Welcome to my website


### PR DESCRIPTION
## 概要
会社HPの採用活動ページ（reqruit.html）を非表示にします。

## 変更内容
- **リンクの非表示**: グローバルナビゲーション（\`_includes/header.html\`）から採用活動ページへのリンクを削除
- **ページの非表示**: \`reqruit.md\` に \`published: false\` を設定し、Jekyll がページ（reqruit.html）を生成しないように変更

## 補足
- 採用活動ページのソース（\`reqruit.md\` / \`_layouts/reqruit.html\`）自体は残しているため、再公開時は \`published: false\` の削除とナビリンクの復帰で元に戻せます。
- \`_layouts/business.html\` の「人材採用サポート」は事業内容の記載であり採用活動ページへのリンクではないため、変更していません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)